### PR TITLE
Add granular composer install routine for WordPress plugins/themes

### DIFF
--- a/bin/modules/WPControl/Configure.pm
+++ b/bin/modules/WPControl/Configure.pm
@@ -12,7 +12,7 @@ use Term::ANSIScreen qw(cls);
 use lib(dirname(abs_path(__FILE__)) . "/../modules");
 use WPControl::Config qw(get_configuration save_configuration write_config_file);
 use WPControl::Utility qw(
-    splash generate_rand_str validate_required_fields
+    splash generate_rand_str validate_required_fields wordpress_composer_install
 );
 use WPControl::RefreshKeysAndSalts qw(refresh_keys_and_salts);
 
@@ -149,10 +149,12 @@ sub configure {
         prompt_db_install();
         do_db_backup();
         prompt_admin_password();
+        prompt_composer_installs();
         prompt_finalize();
     } else {
         # run keys and salts if it doesn't exist:
         -e $keysAndSalts or refresh_keys_and_salts();
+        wordpress_composer_install(1);
 
         print "\nConfiguration completed in non-interactive mode.\n";
         print "Note: If this is a fresh install, be sure to manually run the following commands as needed:\n\n";
@@ -160,7 +162,8 @@ sub configure {
         print "  bin/install-wp-skeleton         # Install or update site code, plugins, and themes\n";
         print "  bin/install-wp-db               # Install the WordPress database tables\n";
         print "  bin/db-backup                   # Install the WordPress database tables\n";
-        print "  bin/refresh-wp-keys-and-salts   # Refresh security keys and invalidate existing sessions\n\n";
+        print "  bin/refresh-wp-keys-and-salts   # Refresh security keys and invalidate existing sessions\n";
+        print "  bin/wordpress-composer-install  # 'composer install' for each plugin and theme\n\n";
     }
 }
 
@@ -459,6 +462,21 @@ sub prompt_admin_password {
 
       update_wordpress_user_password($email, $password);
   }
+}
+
+sub prompt_composer_installs {
+    print "\n=================================================================\n";
+    print " Composer Install for Plugins and Themes\n";
+    print "=================================================================\n\n";
+
+    print "This will check for composer.json files inside wp-content plugins and themes\n";
+    print "and allow you to run 'composer install' for each one interactively.\n";
+    print "You can run this step again manually later using: bin/wordpress-composer-install\n\n";
+
+    my $answer = prompt('y', "⚙️  Run composer install for themes/plugins now?", '', 'y');
+    return unless $answer;
+
+    wordpress_composer_install(0);
 }
 
 sub do_db_backup {

--- a/bin/wordpress-composer-install
+++ b/bin/wordpress-composer-install
@@ -1,0 +1,48 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Cwd qw(getcwd abs_path);
+use File::Basename;
+use lib(dirname(abs_path(__FILE__)) . "/modules");
+use WPControl::Utility qw(wordpress_composer_install);
+
+# Parse argument
+my $arg = shift @ARGV // '';
+my $auto_run = 0;
+
+# Help flags
+if ($arg eq '--help' || $arg eq '-h' || $arg eq 'help') {
+    show_help();
+    exit(0);
+}
+
+# CI/CD mode
+if ($arg eq '--non-interactive') {
+    $auto_run = 1;
+}
+elsif ($arg ne '') {
+    print "❌ Unknown option: '$arg'\n";
+    show_help();
+    exit(1);
+}
+
+# Main behavior
+wordpress_composer_install($auto_run);
+exit(0);
+
+# Help message
+sub show_help {
+    print <<'EOF';
+
+📦 Usage: bin/wordpress-composer-install [option]
+
+Available options:
+  --non-interactive   Run all composer installs without prompting (CI/CD mode).
+  help, -h, --help    Show this help message.
+
+If no option is provided, prompts will be shown for each composer.json found.
+
+EOF
+}


### PR DESCRIPTION
- Introduced `bin/wordpress-composer-install` script
  * Detects composer.json in themes, plugins, mu-plugins
  * Prompts user to run `composer install` per subdirectory
  * Supports `--non-interactive` mode for CI/CD automation
  * Outputs result and exit status clearly
  * Restores original working directory after each install

- Added `wordpress_composer_install()` to WPControl::Utility
  * Exported publicly for use in other modules
  * Accepts boolean flag to toggle interactive vs automated install
  * Uses system composer and PHP paths inside application directory

- Modified WPControl::Configure:
  * Automatically runs `wordpress_composer_install(1)` in non-interactive mode
  * Added interactive `prompt_composer_installs()` during post-config sequence
  * Imports `wordpress_composer_install` into module scope

- Updated configuration script output:
  * Adds bin/wordpress-composer-install to post-config script recommendations